### PR TITLE
configurable chart granularity

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,22 @@ entity: weather.home
 
 ##### Card options
 
-| Name            | Type    | Default                  | Description                                                                                        |
-| --------------- | ------- | -------------------------|--------------------------------------------------------------------------------------------------- |
-| type            | string  | **Required**             | Should be `custom:weather-chart-card`                                                              |
-| entity          | string  | **Required**             | An entity_id with the `weather` domain                                                             |
-| title           | string  | none                     | Card title                                                                                         |
-| show_main       | boolean | true                     | Show or hide a section with current weather condition and temperature                              |
-| show_attributes | boolean | true                     | Show or hide a section with attributes such as pressure, humidity, wind direction and speed, etc   |
-| icons           | string  | none                     | Path to the location of custom icons in svg format, for example `/local/weather-icons/`            |
-| icons_size      | number  | 25                       | The size of custom icons in pixels                                                                 |
-| units           | object  | none                     | See [units of measurement](#units-of-measurement) for available options                            |
-| temp1_color     | string  | rgba(230, 100, 100, 1.0) | Temperature first line chart color                                                                 |
-| temp2_color     | string  | rgba(68, 115, 158, 1.0)  | Temperature second line chart color                                                                |
-| precip_color    | string  | rgba(132, 209, 253, 1.0) | Precipitation bar chart color                                                                      |
+| Name                | Type    | Default                  | Description                                                                                         |
+| ------------------- | ------- | -------------------------|---------------------------------------------------------------------------------------------------- |
+| type                | string  | **Required**             | Should be `custom:weather-chart-card`                                                               |
+| entity              | string  | **Required**             | An entity_id with the `weather` domain                                                              |
+| title               | string  | none                     | Card title                                                                                          |
+| show_main           | boolean | true                     | Show or hide a section with current weather condition and temperature                               |
+| show_attributes     | boolean | true                     | Show or hide a section with attributes such as pressure, humidity, wind direction and speed, etc    |
+| icons               | string  | none                     | Path to the location of custom icons in svg format, for example `/local/weather-icons/`             |
+| icons_size          | number  | 25                       | The size of custom icons in pixels                                                                  |
+| units               | object  | none                     | See [units of measurement](#units-of-measurement) for available options                             |
+| temp1_color         | string  | rgba(230, 100, 100, 1.0) | Temperature first line chart color                                                                  |
+| temp2_color         | string  | rgba(68, 115, 158, 1.0)  | Temperature second line chart color                                                                 |
+| precip_color        | string  | rgba(132, 209, 253, 1.0) | Precipitation bar chart color                                                                       |
+| max_chart_lookahead | number  | 0                        | Desired lookahead elements for forecast chart.  Default is fist `n` elements based on card width.\* |
+
+\* For the `forecast` in your `entity` object, the maximum number of elements to look ahead to display on the chart that will fit within your card's width swapping granularity for lookahead time.  For example, if you have 24 hours of hourly weather in your weather entity, set this value to 18, and your card can display 8 elements, your chart would display 8 elemnts at 2 hour intervals dropping the last 2 hourlies in the desired window, but making sure to display as much data as possible.
 
 ##### Units of measurement
 

--- a/src/main.js
+++ b/src/main.js
@@ -73,6 +73,7 @@ class WeatherChartCard extends LitElement {
       this.windSpeed = this.weather.attributes.wind_speed;
       this.windDirection = this.weather.attributes.wind_bearing;
     }
+    this.maxChartLookahead = this.config.max_chart_lookahead ? this.config.max_chart_lookahead : 0;
   }
 
   constructor() {
@@ -133,6 +134,16 @@ class WeatherChartCard extends LitElement {
     this.forecastItems = Math.round(card.offsetWidth / (fontSize * 5.5));
   }
 
+  getForecast(weather, forecastItems) {
+    if (this.maxChartLookahead == 0 ) {
+      return weather.attributes.forecast.slice(0, forecastItems);
+    } else {
+      var hoursPerEntity = parseInt(Math.min(weather.attributes.forecast.length, this.maxChartLookahead)/forecastItems);
+      var tmpForecast = weather.attributes.forecast.slice(0, forecastItems * hoursPerEntity);
+      return tmpForecast.filter((e, i) => i % hoursPerEntity === (hoursPerEntity - 1));
+    }
+  }
+
   drawChart({config, language, weather, forecastItems} = this) {
     if (!weather || !weather.attributes || !weather.attributes.forecast) {
       return [];
@@ -143,7 +154,7 @@ class WeatherChartCard extends LitElement {
     var tempUnit = this._hass.config.unit_system.temperature;
     var lengthUnit = this._hass.config.unit_system.length;
     var precipUnit = lengthUnit === 'km' ? this.ll('units')['mm'] : this.ll('units')['in'];
-    var forecast = weather.attributes.forecast.slice(0, forecastItems);
+    var forecast = this.getForecast(weather, forecastItems);
     if ((new Date(forecast[1].datetime) - new Date(forecast[0].datetime)) < 864e5)
       var mode = 'hourly';
     else
@@ -330,7 +341,7 @@ class WeatherChartCard extends LitElement {
     if (!weather || !weather.attributes || !weather.attributes.forecast) {
       return [];
     }
-    var forecast = weather.attributes.forecast.slice(0, forecastItems);
+    var forecast = this.getForecast(weather, forecastItems);
     var i;
     var dateTime = [];
     var tempHigh = [];


### PR DESCRIPTION
*Background*

I tend to get up very early in the morning (2a) and walking past my wall panel to look at the day I cannot get a good sense for what the hourly forecast is going to do since (on my machine) it only shows 8 hours which takes me up to 10a.  I would like to instead see the hourly display for every other hour giving me a better picture of the entire day, but obviously less granularity.

*Solution*

I added a configuration option (I really struggled on the name, happy to change it) that allows changing the granularity of the chart graph, up to the maximum size of your weather forecast.  The default should remain unchanged for everyone which is to just display the first `n` elements.