### PR TITLE
fix: handle exceptional weather state

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -7,6 +7,7 @@ const cardinalDirectionsIcon = [
 const weatherIcons = {
   'clear-night': 'hass:weather-night',
   'cloudy': 'hass:weather-cloudy',
+  'exceptional': 'mdi:alert-circle-outline',
   'fog': 'hass:weather-fog',
   'hail': 'hass:weather-hail',
   'lightning': 'hass:weather-lightning',
@@ -24,6 +25,7 @@ const weatherIcons = {
 const weatherIconsDay = {
   'clear-night': 'clear-night',
   'cloudy': 'cloudy',
+  'exceptional': 'exceptional',
   'fog': 'fog',
   'hail': 'hail',
   'lightning': 'lightning',


### PR DESCRIPTION
If the associated weather entity state or any of the forecast states are `exceptional` as specified in the [Condition mappings of the Weather integration](https://www.home-assistant.io/integrations/weather/) the card behaviour is not optional. With default icons the card renders with no icon on the current weather state and missing icons in the forecasts as shown in the following screenshot:

![Screenshot 2022-03-10 at 21 24 27](https://user-images.githubusercontent.com/13124764/157740466-9cc3cab0-2cc8-4538-8477-7a10a393814e.png)

When using custom icons the card renders with missing images as follows:

![Screenshot 2022-03-10 at 21 26 15](https://user-images.githubusercontent.com/13124764/157740697-acc24706-1614-45df-922e-7e8dc0feebdd.png)

This change fixes both scenarios so that when using the default icons, the card renders using `mdi:alert-circle-outline`. This icon is also used by the built-in Home Assistant frontend [weather forecast card](https://github.com/home-assistant/frontend/blob/f89b8cffcf7f32032e72805727b572737e8d8798/src/data/weather.ts#L60)

When using custom icons, the card refers to `exceptional.svg` file in the custom icons folder. Working versions:

Default icons:

![Screenshot 2022-03-10 at 21 38 14](https://user-images.githubusercontent.com/13124764/157741497-f2411492-1cce-40a2-851b-553202da92b6.png)

Custom icons:

![Screenshot 2022-03-10 at 21 37 17](https://user-images.githubusercontent.com/13124764/157741528-83ffcced-1a3d-4e35-a650-6d04615d8217.png)

