### PR TITLE
New option to report precipitation type in rainfall or probability format

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ entity: weather.home
 | title                | string  | none                     | Card title.                                                                                        |
 | show_main            | boolean | true                     | Show or hide a section with current weather condition and temperature.                             |
 | show_attributes      | boolean | true                     | Show or hide a section with attributes such as pressure, humidity, wind direction and speed, etc.  |
+| precipitation_type   | string  | rainfall                 | Show precipitation in either rainfall or probability.                                              |
 | icons                | string  | none                     | Path to the location of custom icons in svg format, for example `/local/weather-icons/`.           |
 | icons_size           | number  | 25                       | The size of custom icons in pixels.                                                                |
-| forecast             | object  | none                     | See [forecast options](#forecast-options) for available options.                       |
+| forecast             | object  | none                     | See [forecast options](#forecast-options) for available options.                                   |
 | units                | object  | none                     | See [units of measurement](#units-of-measurement) for available options.                           |
 
 ##### Forecast options

--- a/src/main.js
+++ b/src/main.js
@@ -143,7 +143,7 @@ class WeatherChartCard extends LitElement {
     }
     var tempUnit = this._hass.config.unit_system.temperature;
     var lengthUnit = this._hass.config.unit_system.length;
-    if (config.precipitation_type === 'percentage') {
+    if (config.precipitation_type === 'probability') {
       var precipUnit = '%';
     } else {
       var precipUnit = lengthUnit === 'km' ? this.ll('units')['mm'] : this.ll('units')['in'];
@@ -165,7 +165,7 @@ class WeatherChartCard extends LitElement {
       if (typeof d.templow !== 'undefined') {
         tempLow.push(d.templow);
       }
-      if (config.precipitation_type === 'percentage') {
+      if (config.precipitation_type === 'probability') {
         precip.push(d.precipitation_probability);
       } else {
         precip.push(d.precipitation);

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,8 @@ class WeatherChartCard extends LitElement {
   static getStubConfig() {
     return {
       "show_main": true,
-      "show_attributes": true
+      "show_attributes": true,
+      "precipitation_type": 'rainfall'
     };
   }
 
@@ -142,7 +143,11 @@ class WeatherChartCard extends LitElement {
     }
     var tempUnit = this._hass.config.unit_system.temperature;
     var lengthUnit = this._hass.config.unit_system.length;
-    var precipUnit = lengthUnit === 'km' ? this.ll('units')['mm'] : this.ll('units')['in'];
+    if (config.precipitation_type === 'percentage') {
+      var precipUnit = '%';
+    } else {
+      var precipUnit = lengthUnit === 'km' ? this.ll('units')['mm'] : this.ll('units')['in'];
+    }
     var forecast = weather.attributes.forecast.slice(0, forecastItems);
     if ((new Date(forecast[1].datetime) - new Date(forecast[0].datetime)) < 864e5)
       var mode = 'hourly';
@@ -160,7 +165,11 @@ class WeatherChartCard extends LitElement {
       if (typeof d.templow !== 'undefined') {
         tempLow.push(d.templow);
       }
-      precip.push(d.precipitation);
+      if (config.precipitation_type === 'percentage') {
+        precip.push(d.precipitation_probability);
+      } else {
+        precip.push(d.precipitation);
+      }
     }
     var style = getComputedStyle(document.body);
     var backgroundColor = style.getPropertyValue('--card-background-color');
@@ -326,7 +335,7 @@ class WeatherChartCard extends LitElement {
     });
   }
 
-  updateChart({weather, forecastItems, forecastChart} = this) {
+  updateChart({config, weather, forecastItems, forecastChart} = this) {
     if (!weather || !weather.attributes || !weather.attributes.forecast) {
       return [];
     }
@@ -343,7 +352,11 @@ class WeatherChartCard extends LitElement {
       if (typeof d.templow !== 'undefined') {
         tempLow.push(d.templow);
       }
-      precip.push(d.precipitation);
+      if (config.precipitation_type === 'percentage') {
+        precip.push(d.precipitation_probability);
+      } else {
+        precip.push(d.precipitation);
+      }
     }
     if (forecastChart) {
       forecastChart.data.labels = dateTime;


### PR DESCRIPTION
New parameter "precipitation_type" that will accept "probability" or "rainfall"
![image](https://github.com/Yevgenium/weather-chart-card/assets/96509060/f20f28c3-4be8-4e4d-98cb-5fb3cc3eacf4)
